### PR TITLE
Add car-cdr-powerset lemma

### DIFF
--- a/proofs
+++ b/proofs
@@ -50,6 +50,13 @@ Lemma greater-equal-subset:
 
 (len2 (car (add-subset ls acc))) > (len2 (car (add-subset ls (cdr acc))))
 
+*Main Lemma*
+;; Lemma 6: car-cdr-powerset
+(implies (and (lorp ls) (descending ls) (lolorp (powerset ls)))
+(equal 
+(and (endp (car (powerset ls))) (consp (car (cdr (powerset ls))))) nil))
+
+
 
 ;; Main proof:
 


### PR DESCRIPTION
Note: this lemma used to prove that the condition (endp (car (powerset ls))) (consp (car (cdr (powerset ls))))) in descending-powerset-help will never be true